### PR TITLE
Fix for wrong declared maven version

### DIFF
--- a/es-maven-plugin/pom.xml
+++ b/es-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.fuin.esmp</groupId>
 		<artifactId>es-maven-parent</artifactId>
-		<version>${version}</version>
+		<version>0.3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>es-maven-plugin</artifactId>
@@ -95,11 +95,9 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
-						<!-- Necessary for Java 8 because it fails parsing the Maven @param tags 
 						<configuration>
 							<additionalparam>-Xdoclint:none</additionalparam>
 						</configuration>
-						 -->
 					</execution>
 				</executions>
 			</plugin>

--- a/es-maven-plugin/src/main/java/org/fuin/esmp/AbstractEventStoreMojo.java
+++ b/es-maven-plugin/src/main/java/org/fuin/esmp/AbstractEventStoreMojo.java
@@ -72,10 +72,10 @@ public abstract class AbstractEventStoreMojo extends AbstractMojo {
     private String archiveName;
 
     /**
-     * Version of the archive (Like "3.0.3"). This is used to construct an
+     * Version of the archive (Like "3.0.5"). This is used to construct an
      * archive URl for the OS where the build script is executed.
      * 
-     * @parameter expression="${archive-version}" default-value="3.0.3"
+     * @parameter expression="${archive-version}" default-value="3.0.5"
      */
     private String archiveVersion = "3.0.5";
 
@@ -293,7 +293,7 @@ public abstract class AbstractEventStoreMojo extends AbstractMojo {
     }
 
     /**
-     * Returns the version of the archive (Like "3.0.3").
+     * Returns the version of the archive (Like "3.0.5").
      * 
      * @return Event store version.
      */
@@ -302,7 +302,7 @@ public abstract class AbstractEventStoreMojo extends AbstractMojo {
     }
 
     /**
-     * Sets the version of the archive (Like "3.0.3").
+     * Sets the version of the archive (Like "3.0.5").
      * 
      * @param archiveVersion
      *            The event store version to set.

--- a/es-maven-plugin/src/main/java/org/fuin/esmp/EventStoreStartMojo.java
+++ b/es-maven-plugin/src/main/java/org/fuin/esmp/EventStoreStartMojo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Michael Schnell. All rights reserved. 
+ * Copyright (C) 2015 Michael Schnell. All rights reserved.
  * <http://www.fuin.org/>
  *
  * This library is free software; you can redistribute it and/or modify it under
@@ -23,18 +23,14 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.exec.CommandLine;
-import org.apache.commons.exec.DaemonExecutor;
-import org.apache.commons.exec.DefaultExecuteResultHandler;
-import org.apache.commons.exec.OS;
-import org.apache.commons.exec.PumpStreamHandler;
+import org.apache.commons.exec.*;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * A customizable source code generator plugin for maven.
- * 
+ *
  * @goal start
  * @phase pre-integration-test
  * @requiresProject false
@@ -48,7 +44,7 @@ public final class EventStoreStartMojo extends AbstractEventStoreMojo {
      * Name of the executable or shell script to start the event store. Defaults
      * to the OS specific name for Windows, Linux and Mac OS families. Other OS
      * families will cause an error if this value is not set.
-     * 
+     *
      * @parameter expression="${command}"
      */
     private String command;
@@ -56,7 +52,7 @@ public final class EventStoreStartMojo extends AbstractEventStoreMojo {
     /**
      * Command line arguments to pass to the executable. If no arguments are set
      * this defaults to <code>--mem-db=TRUE</code>.
-     * 
+     *
      * @parameter
      */
     private String[] arguments;
@@ -66,7 +62,7 @@ public final class EventStoreStartMojo extends AbstractEventStoreMojo {
      * this time passed, the build will fail. This means the mojo will wait
      * <code>maxWaitCycles</code> * <code>sleepMillis</code> milliseconds for
      * the server to finish it's startup process. Defaults to 20 times.
-     * 
+     *
      * @parameter expression="${max-wait-cycles}" default-value="20"
      */
     private int maxWaitCycles = 20;
@@ -76,14 +72,21 @@ public final class EventStoreStartMojo extends AbstractEventStoreMojo {
      * the mojo will wait <code>maxWaitCycles</code> * <code>sleepMillis</code>
      * milliseconds for the server to finish it's startup process. Defaults to
      * 500 ms.
-     * 
+     *
      * @parameter expression="${sleep-ms}" default-value="500"
      */
     private int sleepMillis = 500;
 
     /**
+     * Name of an executable or shell script which is executed after successful start the event store.
+     *
+     * @parameter expression="${postStartCommand}"
+     */
+    private String postStartCommand;
+
+    /**
      * Message from the event store log to wait for.
-     * 
+     *
      * @parameter expression="${up-message}"
      *            default-value="'admin' user account has been created"
      */
@@ -115,6 +118,21 @@ public final class EventStoreStartMojo extends AbstractEventStoreMojo {
             final String pid = extractPid(messages);
             LOG.info("Event store process ID: {}", pid);
             writePid(pid);
+
+            if (null != postStartCommand) {
+                try {
+                    final DefaultExecutor postCommandExecutor = new DefaultExecutor();
+                    final int retVal = postCommandExecutor.execute(new CommandLine(postStartCommand));
+                    if (0 == retVal) {
+                        LOG.info("Post-start command executed successfully");
+                    } else {
+                        LOG.warn("Post-start command returned result code {}", retVal);
+                    }
+                } catch (final IOException e) {
+                    LOG.error("Could not execute post-start command", e);
+                    new EventStoreStopMojo().executeGoal();
+                }
+            }
         } catch (final IOException ex) {
             throw new MojoExecutionException(
                     "Error executing the command line: " + cmdLine, ex);
@@ -229,7 +247,7 @@ public final class EventStoreStartMojo extends AbstractEventStoreMojo {
     /**
      * Returns the name of the executable or shell script to start the event
      * store.
-     * 
+     *
      * @return Executable name.
      */
     public final String getCommand() {
@@ -238,7 +256,7 @@ public final class EventStoreStartMojo extends AbstractEventStoreMojo {
 
     /**
      * Sets the name of the executable or shell script to start the event store.
-     * 
+     *
      * @param command
      *            Executable name to set.
      */
@@ -248,7 +266,7 @@ public final class EventStoreStartMojo extends AbstractEventStoreMojo {
 
     /**
      * Returns the command line arguments to pass to the executable.
-     * 
+     *
      * @return Command line arguments.
      */
     public final String[] getArguments() {
@@ -257,7 +275,7 @@ public final class EventStoreStartMojo extends AbstractEventStoreMojo {
 
     /**
      * Sets the command line arguments to pass to the executable.
-     * 
+     *
      * @param arguments
      *            Arguments to set
      */

--- a/es-maven-test/pom.xml
+++ b/es-maven-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.fuin.esmp</groupId>
 		<artifactId>es-maven-parent</artifactId>
-		<version>${version}</version>
+		<version>0.3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>es-maven-test</artifactId>

--- a/es-maven-test/src/test/resources/test-project/pom.xml
+++ b/es-maven-test/src/test/resources/test-project/pom.xml
@@ -60,7 +60,7 @@
 			<plugin>
 				<groupId>org.fuin.esmp</groupId>
 				<artifactId>es-maven-plugin</artifactId>
-				<version>0.3.0-SNAPSHOT</version>
+				<version>0.3.1-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.fuin.esmp</groupId>
 	<artifactId>es-maven-parent</artifactId>
-	<version>${version}</version>
+	<version>0.3.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>es-maven-parent</name>
 	<description>This Maven plugin provides goals that starts/stops the event store [PARENT].</description>
@@ -27,10 +27,6 @@
 		<system>GitHub Issues</system>
 		<url>https://github.com/fuinorg/event-store-maven-plugin/issues</url>
 	</issueManagement>
-
-    <properties>
-        <version>0.3.0</version>
-    </properties>
 
 	<modules>
 		<module>es-maven-plugin</module>


### PR DESCRIPTION
Hi again,

thx for releasing v0.3.0 but unfortunately the `${version}` property which is declared in the parent POM is not accessible from it's child if the plugin is used by some external project.
This pull request is fixing this - for upcoming releases you could use the maven versions plugin:
`mvn versions:update-child-modules` after you updated the version of the parent POM. However you still have to manually maintain the version in `es-maven-test/src/test/resources/test-project/pom.xml`.

Additionally I've added a new feature for executing commands after successful start of EventStore.

Br,
Michael
